### PR TITLE
feat/seed-data: Add user, comment and post schema and implement seed functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@
 
 # The database URL is used to connect to your database.
 POSTGRES_URL="postgres://postgres:example@localhost:5432/react-table-dev"
+UID=
+GID=
+DB_PWD=

--- a/apps/nextjs/src/app/_lib/actions.ts
+++ b/apps/nextjs/src/app/_lib/actions.ts
@@ -5,6 +5,7 @@ import { asc, eq, inArray, not } from "drizzle-orm";
 import { customAlphabet } from "nanoid";
 
 import type {
+  CreatePostSchema,
   CreateTaskSchema,
   CreateViewSchema,
   DeleteViewSchema,
@@ -17,10 +18,11 @@ import {
   createViewSchema,
   deleteViewSchema,
   editViewSchema,
+  posts,
   tasks,
   views,
 } from "@acme/db/schema";
-import { generateRandomTask } from "@acme/db/util";
+import { generateRandomPost, generateRandomTask } from "@acme/db/util";
 
 import type { ViewItem } from "~/components/data-table/advanced/views/data-table-views-dropdown";
 import { getErrorMessage } from "~/lib/handle-error";
@@ -82,6 +84,64 @@ export async function createTask(input: CreateTaskSchema) {
   }
 }
 
+export async function createPost(input: CreatePostSchema) {
+  noStore();
+  try {
+    const status =
+      input.status === "todo" ||
+      input.status === "in-progress" ||
+      input.status === "done" ||
+      input.status === "canceled"
+        ? input.status
+        : "todo";
+
+    await db.transaction(async (tx) => {
+      const newPost = await tx
+        .insert(posts)
+        .values({
+          title: input.title,
+          author: input.author,
+          status: status,
+          nbComments: input.nbComments ?? 0,
+        })
+        .returning({
+          id: posts.id,
+        })
+        .then(takeFirstOrThrow);
+
+      // Optional logic: for example, limiting the number of posts by deleting old ones
+      await tx.delete(posts).where(
+        eq(
+          posts.id,
+          (
+            await tx
+              .select({
+                id: posts.id,
+              })
+              .from(posts)
+              .limit(1)
+              .where(not(eq(posts.id, newPost.id)))
+              .orderBy(asc(posts.createdAt))
+              .then(takeFirstOrThrow)
+          ).id,
+        ),
+      );
+    });
+
+    revalidatePath("/");
+
+    return {
+      data: null,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      data: null,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
 export async function updateTask(input: UpdateTaskSchema & { id: string }) {
   noStore();
   try {
@@ -90,6 +150,32 @@ export async function updateTask(input: UpdateTaskSchema & { id: string }) {
       .set({
         title: input.title,
         label: input.label,
+        status: input.status,
+        priority: input.priority,
+      })
+      .where(eq(tasks.id, input.id));
+
+    revalidatePath("/");
+
+    return {
+      data: null,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      data: null,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
+export async function updatePost(input: any) {
+  noStore();
+  try {
+    await db
+      .update(tasks)
+      .set({
+        title: input.title,
         status: input.status,
         priority: input.priority,
       })
@@ -140,6 +226,35 @@ export async function updateTasks(input: {
   }
 }
 
+export async function updatePosts(input: {
+  ids: string[];
+  title?: string;
+  status?: "todo" | "in-progress" | "done" | "canceled";
+}) {
+  noStore();
+  try {
+    await db
+      .update(posts)
+      .set({
+        title: input.title,
+        status: input.status,
+      })
+      .where(inArray(posts.id, input.ids));
+
+    revalidatePath("/");
+
+    return {
+      data: null,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      data: null,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
 export async function deleteTask(input: { id: string }) {
   try {
     await db.transaction(async (tx) => {
@@ -165,6 +280,29 @@ export async function deleteTasks(input: { ids: string[] }) {
 
       // Create new tasks for the deleted ones
       await tx.insert(tasks).values(input.ids.map(() => generateRandomTask()));
+    });
+
+    revalidatePath("/");
+
+    return {
+      data: null,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      data: null,
+      error: getErrorMessage(err),
+    };
+  }
+}
+
+export async function deletePosts(input: { ids: string[] }) {
+  try {
+    await db.transaction(async (tx) => {
+      await tx.delete(posts).where(inArray(posts.id, input.ids));
+
+      // Create new posts for the deleted ones
+      // await tx.insert(posts).values(input.ids.map(() => generateRandomPost()));
     });
 
     revalidatePath("/");
@@ -347,18 +485,6 @@ export async function editView(
       message: "View updated",
     };
   } catch (err) {
-    if (
-      typeof err === "object" &&
-      err &&
-      "code" in err &&
-      err.code === "23505"
-    ) {
-      return {
-        status: "error",
-        message: `A view with the name "${validatedFields.data.name}" already exists`,
-      };
-    }
-
     return {
       status: "error",
       message: getErrorMessage(err),
@@ -366,41 +492,24 @@ export async function editView(
   }
 }
 
-type DeleteViewFormState = CreateFormState<DeleteViewSchema>;
-
-export async function deleteView(
-  _prevState: DeleteViewFormState,
-  formData: FormData,
-): Promise<DeleteViewFormState> {
+export async function deleteView(input: DeleteViewSchema) {
   noStore();
 
-  const id = formData.get("id");
-
-  const validatedFields = deleteViewSchema.safeParse({
-    id,
-  });
-
-  if (!validatedFields.success) {
-    const errorMap = validatedFields.error.flatten().fieldErrors;
-    return {
-      status: "error",
-      message: errorMap.id?.[0] ?? "",
-    };
-  }
-
   try {
-    await db.delete(views).where(eq(views.id, validatedFields.data.id));
-
+    await db.delete(views).where(eq(views.id, input.id));
     revalidatePath("/");
-
     return {
+      data: null,
+      error: null,
+      message: "View deleted successfully",
       status: "success",
-      message: "View deleted",
     };
   } catch (err) {
     return {
+      data: null,
+      error: getErrorMessage(err),
+      message: "Error deleting view",
       status: "error",
-      message: getErrorMessage(err),
     };
   }
 }

--- a/apps/nextjs/src/components/data-table/advanced/views/delete-view-form.tsx
+++ b/apps/nextjs/src/components/data-table/advanced/views/delete-view-form.tsx
@@ -3,6 +3,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useFormState, useFormStatus } from "react-dom";
 import { toast } from "sonner";
 
+import { DeleteViewSchema } from "@acme/db/schema";
 import { Button } from "@acme/ui/button";
 import { LoaderIcon } from "@acme/ui/loader-icon";
 
@@ -21,7 +22,7 @@ export function DeleteViewForm({
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const [state, formAction] = useFormState(deleteView, {
+  const [state, formAction] = useFormState<any>(deleteView, {
     message: "",
   });
 
@@ -35,7 +36,6 @@ export function DeleteViewForm({
     } else if (state.status === "error") {
       toast.error(state.message);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, setIsEditViewFormOpen]);
 
   return (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: "${DB_PWD}"
       POSTGRES_DB: react-table-dev
     ports:
       - "5432:5432"
-    user: "${UID}:${GID}"

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -82,8 +82,8 @@ export type UpdatePostSchema = z.infer<typeof updatePostSchema>;
 
 export const comments = pgTable("comments", {
   id: uuid("id").notNull().primaryKey().defaultRandom(),
-  postId: uuid("post_id").notNull(),  // Reference to the post
-  authorId: uuid("author_id").notNull(),  // Reference to the user (author)
+  postId: uuid("post_id").notNull(), // Reference to the post
+  authorId: uuid("author_id").notNull(), // Reference to the user (author)
   content: text("content").notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -10,20 +10,9 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
-import { number, z } from "zod";
+import { z } from "zod";
 
 //////////////////////// POSTS ////////////////////////
-
-// export const Post = pgTable("post", {
-//   id: uuid("id").notNull().primaryKey().defaultRandom(),
-//   title: varchar("name", { length: 256 }).notNull(),
-//   content: text("content").notNull(),
-//   createdAt: timestamp("created_at").defaultNow().notNull(),
-//   updatedAt: timestamp("updatedAt", {
-//     mode: "date",
-//     withTimezone: true,
-//   }).$onUpdateFn(() => sql`now()`),
-// });
 
 export const postStatusEnum = pgEnum(`status`, [
   "todo",
@@ -206,6 +195,8 @@ export type EditViewSchema = z.infer<typeof editViewSchema>;
 
 export const deleteViewSchema = z.object({
   id: z.string().uuid(),
+  message: z.string(),
+  status: z.string(),
 });
 
 export type DeleteViewSchema = z.infer<typeof deleteViewSchema>;

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,7 +1,12 @@
 import type { Task } from "./schema";
 import { db } from "./client";
-import { tasks } from "./schema";
-import { generateRandomTask } from "./util";
+import { comments, posts, tasks, users } from "./schema";
+import {
+  generateRandomComment,
+  generateRandomPost,
+  generateRandomTask,
+  generateRandomUser,
+} from "./util";
 
 async function seedTasks(input: { count: number | null }) {
   const count = input.count ?? 100;
@@ -22,16 +27,57 @@ async function seedTasks(input: { count: number | null }) {
   }
 }
 
-function _seedPosts(_input: { count: number }) {
-  // TODO: Implement this function
+async function _seedPosts(_input: { count: number | null }) {
+  const count = _input.count ?? 100; // Default to 100 if no count is provided
+  const allPosts = [];
+
+  try {
+    for (let i = 0; i < count; i++) {
+      allPosts.push(generateRandomPost());
+    }
+
+    console.log("📝 Inserting posts", allPosts.length);
+    await db.delete(posts);
+
+    await db.insert(posts).values(allPosts);
+  } catch (err) {
+    console.error(err);
+  }
 }
 
-function _seedUsers(_input: { count: number }) {
-  // TODO: Implement this function
+async function _seedUsers(_input: { count: number | null }) {
+  const count = _input.count ?? 100; // Default to 100 if no count is provided
+  const allUsers = [];
+
+  try {
+    for (let i = 0; i < count; i++) {
+      allUsers.push(generateRandomUser());
+    }
+
+    console.log("📝 Inserting users", allUsers.length);
+    await db.delete(users);
+
+    await db.insert(users).values(allUsers);
+  } catch (err) {
+    console.error(err);
+  }
 }
 
-function _seedComments(_input: { count: number }) {
-  // TODO: Implement this function
+async function _seedComments(_input: { count: number }) {
+  const count = _input.count ?? 100; // Default to 100 if no count is provided
+  const allComments = [];
+
+  try {
+    for (let i = 0; i < count; i++) {
+      allComments.push(generateRandomComment());
+    }
+    console.log("📝 Inserting comments", allComments.length);
+    await db.delete(comments);
+
+    await db.insert(comments).values(allComments);
+  } catch (err) {
+    console.error(err);
+  }
 }
 
 async function runSeed() {
@@ -39,7 +85,15 @@ async function runSeed() {
 
   const start = Date.now();
 
-  await seedTasks({ count: 100 });
+  const seedCount = 100;
+
+  // Run all seeds concurrently
+  await Promise.all([
+    seedTasks({ count: seedCount }),
+    _seedPosts({ count: seedCount }),
+    _seedUsers({ count: seedCount }),
+    _seedComments({ count: seedCount }),
+  ]);
 
   const end = Date.now();
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -8,8 +8,8 @@ import {
   generateRandomUser,
 } from "./util";
 
-async function seedTasks(input: { count: number | null }) {
-  const count = input.count ?? 100;
+async function seedTasks(input: { count: number }) {
+  const count = input.count;
   try {
     const allTasks: Omit<Task, "id">[] = [];
 
@@ -27,8 +27,8 @@ async function seedTasks(input: { count: number | null }) {
   }
 }
 
-async function _seedPosts(_input: { count: number | null }) {
-  const count = _input.count ?? 100; // Default to 100 if no count is provided
+async function _seedPosts(_input: { count: number }) {
+  const count = _input.count; // Default to 100 if no count is provided
   const allPosts = [];
 
   try {
@@ -45,8 +45,8 @@ async function _seedPosts(_input: { count: number | null }) {
   }
 }
 
-async function _seedUsers(_input: { count: number | null }) {
-  const count = _input.count ?? 100; // Default to 100 if no count is provided
+async function _seedUsers(_input: { count: number }) {
+  const count = _input.count; // Default to 100 if no count is provided
   const allUsers = [];
 
   try {
@@ -64,7 +64,7 @@ async function _seedUsers(_input: { count: number | null }) {
 }
 
 async function _seedComments(_input: { count: number }) {
-  const count = _input.count ?? 100; // Default to 100 if no count is provided
+  const count = _input.count; // Default to 100 if no count is provided
   const allComments = [];
 
   try {

--- a/packages/db/src/util.ts
+++ b/packages/db/src/util.ts
@@ -22,7 +22,7 @@ export function generateRandomPost(): Omit<Post, "id"> {
   return {
     title: faker.lorem.sentence(),
     status:
-      faker.helpers.shuffle(["todo", "in-progress", "done", "canceled"])[0] ||
+      faker.helpers.shuffle(["todo", "in-progress", "done", "canceled"])[0] ??
       "todo",
     author: faker.person.firstName(),
     nbComments: faker.number.int({ min: 0, max: 50 }),

--- a/packages/db/src/util.ts
+++ b/packages/db/src/util.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { customAlphabet } from "nanoid";
 
-import type { Task } from "./schema";
+import type { Post, Task } from "./schema";
 import { tasks } from "./schema";
 
 export function generateRandomTask(): Omit<Task, "id"> {
@@ -13,6 +13,39 @@ export function generateRandomTask(): Omit<Task, "id"> {
     status: faker.helpers.shuffle(tasks.status.enumValues)[0] ?? "todo",
     label: faker.helpers.shuffle(tasks.label.enumValues)[0] ?? "bug",
     priority: faker.helpers.shuffle(tasks.priority.enumValues)[0] ?? "low",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+export function generateRandomPost(): Omit<Post, "id"> {
+  return {
+    title: faker.lorem.sentence(),
+    status:
+      faker.helpers.shuffle(["todo", "in-progress", "done", "canceled"])[0] ||
+      "todo",
+    author: faker.person.firstName(),
+    nbComments: faker.number.int({ min: 0, max: 50 }),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+export function generateRandomUser() {
+  return {
+    id: faker.string.uuid(),
+    name: faker.person.fullName(),
+    email: faker.internet.email(),
+    image: faker.image.avatar(),
+  };
+}
+
+export function generateRandomComment() {
+  return {
+    id: faker.string.uuid(),
+    postId: faker.string.uuid(),
+    authorId: faker.string.uuid(),
+    content: faker.lorem.sentences(),
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/turbo.json
+++ b/turbo.json
@@ -35,6 +35,10 @@
       "cache": false,
       "interactive": true
     },
+    "seed": {
+      "cache": false,
+      "interactive": true
+    },
     "studio": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
### **_Changes made:_**

#### 1. Fill in .env and docker yml files with necessary parameters for DB configs

#### 2. Implement users, comments and posts schemas.

#### 3. Implement seed functions (_seedUsers, _seedComments and _seedPosts)

**pnpm:db push** will create this schema in your DB

![image](https://github.com/user-attachments/assets/c25087a4-b804-4cbb-9dec-fe1e0064b266)

**pnpm:db push** will seed mock data to users, comments, posts and tasks tables

#### Snapshots after running seed command:

![image](https://github.com/user-attachments/assets/ab0539ef-5705-405a-bc6b-1f4277defbfc)

![image](https://github.com/user-attachments/assets/8070b66d-32d6-4fca-aec4-ab3e91196950)

![image](https://github.com/user-attachments/assets/301b8ae3-47b4-4b45-b07c-61a3a249381d)

